### PR TITLE
security: Delay dependabot updates [TAROT-3707]

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,20 +1,22 @@
 version: 2
 updates:
-- package-ecosystem: nuget
-  directory: "/"
-  schedule:
-    interval: daily
-    timezone: Europe/Lisbon
-  open-pull-requests-limit: 10
-  ignore:
-  - dependency-name: SonarAnalyzer.VisualBasic
-    versions:
-    - 8.17.0.26580
-    - 8.18.0.27296
-    - 8.19.0.28253
-    - 8.20.0.28934
-    - 8.21.0.30542
-  - dependency-name: ReverseMarkdown
-    versions:
-    - 3.15.0
-    - 3.18.0
+  - package-ecosystem: nuget
+    directory: "/"
+    schedule:
+      interval: daily
+      timezone: Europe/Lisbon
+    open-pull-requests-limit: 10
+    ignore:
+      - dependency-name: SonarAnalyzer.VisualBasic
+        versions:
+          - 8.17.0.26580
+          - 8.18.0.27296
+          - 8.19.0.28253
+          - 8.20.0.28934
+          - 8.21.0.30542
+      - dependency-name: ReverseMarkdown
+        versions:
+          - 3.15.0
+          - 3.18.0
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
7 days should be enough when most malicious packages are patched within 24 hours.